### PR TITLE
fix: pass correct max length limit for sentry

### DIFF
--- a/sentry.tf
+++ b/sentry.tf
@@ -5,6 +5,8 @@ module "sentry" {
 
   context     = module.this.context
   label_order = var.label_orders.sentry
+
+  id_length_limit = 50
 }
 
 moved {


### PR DESCRIPTION
## Description
Sentry has a maximum limit of 50 characters for the project name and slug. By passing this information to the sentry module, we ensure that it doesn't create names which are too long.

## Breaking Changes
This change is backwards compatible.

## How Has This Been Tested?
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have tested the change locally and was able to create the correct sentry project with it
