### PR TITLE
fix: adapt tracing env vars;

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -136,7 +136,7 @@ module "container_definition" {
     REDIS_DEFAULT_NAMING_PATTERN                      = "!nodecode {name}.{group}.{env}.{family}"
     SENTRY_DSN                                        = try(module.sentry[0].dsn, var.sentry_dsn)
     SENTRY_ENVIRONMENT                                = module.this.environment
-    TRACING_ADDR_TYPE                                 = "srv"
+    TRACING_XRAY_ADDR_TYPE                            = "srv"
     TRACING_PROVIDER                                  = var.tracing_provider
   }, var.container_map_environment)
   map_secrets       = var.container_map_secrets


### PR DESCRIPTION
## Description
With the introduction of OTEL tracing provider the env variables changed to support the different configuration required by each one of them.

## Motivation and Context
Support for OTEL caused some changes in the tracing package which resulted in changing the settings structure.

## Breaking Changes


## How Has This Been Tested?
no testing was done