### PR TITLE
fix: bump gosoline provider to v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Terraform module which creates a ecs app
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67 |
 | <a name="requirement_elasticsearch"></a> [elasticsearch](#requirement\_elasticsearch) | 2.0.7 |
 | <a name="requirement_elasticstack"></a> [elasticstack](#requirement\_elasticstack) | 0.11.11 |
-| <a name="requirement_gosoline"></a> [gosoline](#requirement\_gosoline) | 1.4.1 |
+| <a name="requirement_gosoline"></a> [gosoline](#requirement\_gosoline) | 1.5.0 |
 | <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | 3.10.0 |
 | <a name="requirement_sentry"></a> [sentry](#requirement\_sentry) | 0.13.2 |
 

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
 
     gosoline = {
       source  = "justtrackio/gosoline"
-      version = "1.4.1"
+      version = "1.5.0"
     }
 
     grafana = {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
